### PR TITLE
feat(ui): Migrate card components to shadcn/ui

### DIFF
--- a/cursormvp/app/packages/web-app/package.json
+++ b/cursormvp/app/packages/web-app/package.json
@@ -32,7 +32,7 @@
     "@trpc/react-query": "^11.0.0-rc.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
-    "lucide-react": "^0.446.0",
+    "lucide-react": "^0.555.0",
     "next": "^14.2.0",
     "next-auth": "^5.0.0-beta.22",
     "posthog-js": "^1.298.1",

--- a/cursormvp/app/packages/web-app/src/components/PromptCard.tsx
+++ b/cursormvp/app/packages/web-app/src/components/PromptCard.tsx
@@ -4,10 +4,17 @@
  * PromptCard Component
  *
  * Displays a prompt summary in a card format with quick actions.
+ * Uses shadcn/ui Card component and Lucide icons.
  */
 
 import Link from 'next/link';
+import { PlayCircle, Copy, Pencil } from 'lucide-react';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { TagChip } from './TagFilter';
+import { formatRelativeDate } from '@/lib/date';
 
 interface PromptCardProps {
   /** Prompt ID */
@@ -41,32 +48,11 @@ export function PromptCard({
   tags,
   usageCount,
   isPublic,
-  createdAt,
   updatedAt,
   onCopy,
   onRun,
   onEdit,
 }: PromptCardProps) {
-  const formatDate = (date: Date) => {
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffDays === 0) {
-      return 'Today';
-    } else if (diffDays === 1) {
-      return 'Yesterday';
-    } else if (diffDays < 7) {
-      return `${diffDays} days ago`;
-    } else {
-      return date.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-      });
-    }
-  };
-
   const handleCopy = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -86,146 +72,91 @@ export function PromptCard({
   };
 
   return (
-    <Link href={`/prompts/${id}`} className="block">
-      <article className="card p-4 hover:shadow-md transition-shadow duration-200 h-full flex flex-col">
-        {/* Header */}
-        <div className="flex items-start justify-between gap-2 mb-2">
-          <h3 className="text-base font-semibold text-neutral-900 line-clamp-1">
-            {title}
-          </h3>
-          {isPublic && (
-            <span className="flex-shrink-0 inline-flex items-center rounded-full bg-success-50 px-2 py-0.5 text-xs font-medium text-success-600">
-              Public
-            </span>
-          )}
-        </div>
-
-        {/* Description */}
-        {description && (
-          <p className="text-sm text-neutral-600 line-clamp-2 mb-3">
-            {description}
-          </p>
-        )}
-
-        {/* Tags */}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mb-3">
-            {tags.slice(0, 3).map((tag) => (
-              <TagChip key={tag} tag={tag} size="sm" />
-            ))}
-            {tags.length > 3 && (
-              <span className="inline-flex items-center px-2 py-0.5 text-xs text-neutral-400">
-                +{tags.length - 3} more
-              </span>
+    <Link href={`/prompts/${id}`} className="block h-full">
+      <Card className="h-full flex flex-col hover:shadow-md transition-shadow duration-200">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="text-base font-semibold text-foreground line-clamp-1">
+              {title}
+            </h3>
+            {isPublic && (
+              <Badge variant="success" className="flex-shrink-0">
+                Public
+              </Badge>
             )}
           </div>
-        )}
+        </CardHeader>
 
-        {/* Spacer to push footer to bottom */}
-        <div className="flex-grow" />
+        <CardContent className="flex-grow pb-3">
+          {/* Description */}
+          {description && (
+            <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+              {description}
+            </p>
+          )}
 
-        {/* Footer */}
-        <div className="flex items-center justify-between pt-3 border-t border-neutral-100">
+          {/* Tags */}
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {tags.slice(0, 3).map((tag) => (
+                <TagChip key={tag} tag={tag} size="sm" />
+              ))}
+              {tags.length > 3 && (
+                <span className="inline-flex items-center px-2 py-0.5 text-xs text-muted-foreground">
+                  +{tags.length - 3} more
+                </span>
+              )}
+            </div>
+          )}
+        </CardContent>
+
+        <CardFooter className="pt-3 border-t flex items-center justify-between">
           {/* Stats */}
-          <div className="flex items-center gap-3 text-xs text-neutral-500">
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
             <span className="flex items-center gap-1" title="Usage count">
-              <svg
-                className="h-3.5 w-3.5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <PlayCircle className="h-3.5 w-3.5" />
               {usageCount}
             </span>
             <span title={`Updated ${updatedAt.toLocaleDateString()}`}>
-              {formatDate(updatedAt)}
+              {formatRelativeDate(updatedAt)}
             </span>
           </div>
 
           {/* Quick Actions */}
           <div className="flex items-center gap-1">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
               onClick={handleCopy}
-              className="p-1.5 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100"
               title="Copy prompt"
               aria-label="Copy prompt"
             >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                />
-              </svg>
-            </button>
-            <button
+              <Copy className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:text-primary hover:bg-primary/10"
               onClick={handleRun}
-              className="p-1.5 rounded-md text-neutral-400 hover:text-primary-600 hover:bg-primary-50"
               title="Run prompt"
               aria-label="Run prompt"
             >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-            </button>
-            <button
+              <PlayCircle className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
               onClick={handleEdit}
-              className="p-1.5 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100"
               title="Edit prompt"
               aria-label="Edit prompt"
             >
-              <svg
-                className="h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                />
-              </svg>
-            </button>
+              <Pencil className="h-4 w-4" />
+            </Button>
           </div>
-        </div>
-      </article>
+        </CardFooter>
+      </Card>
     </Link>
   );
 }
@@ -237,36 +168,33 @@ export function PromptCard({
  */
 export function PromptCardSkeleton() {
   return (
-    <div className="card p-4 animate-pulse">
-      {/* Header */}
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="h-5 bg-neutral-200 rounded w-3/4" />
-      </div>
+    <Card className="h-full">
+      <CardHeader className="pb-2">
+        <Skeleton className="h-5 w-3/4" />
+      </CardHeader>
 
-      {/* Description */}
-      <div className="space-y-2 mb-3">
-        <div className="h-4 bg-neutral-100 rounded w-full" />
-        <div className="h-4 bg-neutral-100 rounded w-5/6" />
-      </div>
+      <CardContent className="pb-3">
+        <div className="space-y-2 mb-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+        <div className="flex gap-1.5">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+      </CardContent>
 
-      {/* Tags */}
-      <div className="flex gap-1.5 mb-3">
-        <div className="h-5 bg-neutral-100 rounded-full w-16" />
-        <div className="h-5 bg-neutral-100 rounded-full w-20" />
-      </div>
-
-      {/* Footer */}
-      <div className="flex items-center justify-between pt-3 border-t border-neutral-100">
+      <CardFooter className="pt-3 border-t flex items-center justify-between">
         <div className="flex gap-3">
-          <div className="h-4 bg-neutral-100 rounded w-8" />
-          <div className="h-4 bg-neutral-100 rounded w-16" />
+          <Skeleton className="h-4 w-8" />
+          <Skeleton className="h-4 w-16" />
         </div>
         <div className="flex gap-1">
-          <div className="h-7 w-7 bg-neutral-100 rounded" />
-          <div className="h-7 w-7 bg-neutral-100 rounded" />
-          <div className="h-7 w-7 bg-neutral-100 rounded" />
+          <Skeleton className="h-7 w-7 rounded" />
+          <Skeleton className="h-7 w-7 rounded" />
+          <Skeleton className="h-7 w-7 rounded" />
         </div>
-      </div>
-    </div>
+      </CardFooter>
+    </Card>
   );
 }

--- a/cursormvp/app/packages/web-app/src/components/collections/CollectionCard.tsx
+++ b/cursormvp/app/packages/web-app/src/components/collections/CollectionCard.tsx
@@ -4,9 +4,16 @@
  * CollectionCard Component
  *
  * Displays a collection summary in a card format with quick actions.
+ * Uses shadcn/ui Card component and Lucide icons.
  */
 
 import Link from 'next/link';
+import { Folder, Pencil, Trash2 } from 'lucide-react';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatRelativeDate } from '@/lib/date';
 
 interface CollectionCardProps {
   /** Collection ID */
@@ -37,32 +44,11 @@ export function CollectionCard({
   description,
   promptCount,
   isPublic,
-  createdAt,
   updatedAt,
   isOwner = true,
   onEdit,
   onDelete,
 }: CollectionCardProps) {
-  const formatDate = (date: Date) => {
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffDays === 0) {
-      return 'Today';
-    } else if (diffDays === 1) {
-      return 'Yesterday';
-    } else if (diffDays < 7) {
-      return `${diffDays} days ago`;
-    } else {
-      return date.toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-      });
-    }
-  };
-
   const handleEdit = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -76,114 +62,78 @@ export function CollectionCard({
   };
 
   return (
-    <Link href={`/collections/${id}`} className="block">
-      <article className="card p-4 hover:shadow-md transition-shadow duration-200 h-full flex flex-col">
-        {/* Header */}
-        <div className="flex items-start justify-between gap-2 mb-2">
-          <div className="flex items-center gap-2">
-            {/* Folder icon */}
-            <div className="flex-shrink-0 w-8 h-8 rounded-md bg-primary-50 flex items-center justify-center">
-              <svg
-                className="h-4 w-4 text-primary-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-                />
-              </svg>
+    <Link href={`/collections/${id}`} className="block h-full">
+      <Card className="h-full flex flex-col hover:shadow-md transition-shadow duration-200">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2">
+              {/* Folder icon */}
+              <div className="flex-shrink-0 w-8 h-8 rounded-md bg-primary/10 flex items-center justify-center">
+                <Folder className="h-4 w-4 text-primary" />
+              </div>
+              <h3 className="text-base font-semibold text-foreground line-clamp-1">
+                {name}
+              </h3>
             </div>
-            <h3 className="text-base font-semibold text-neutral-900 line-clamp-1">
-              {name}
-            </h3>
+            {isPublic && (
+              <Badge variant="success" className="flex-shrink-0">
+                Public
+              </Badge>
+            )}
           </div>
-          {isPublic && (
-            <span className="flex-shrink-0 inline-flex items-center rounded-full bg-success-50 px-2 py-0.5 text-xs font-medium text-success-600">
-              Public
-            </span>
+        </CardHeader>
+
+        <CardContent className="flex-grow pb-3">
+          {/* Description */}
+          {description && (
+            <p className="text-sm text-muted-foreground line-clamp-2 mb-3">
+              {description}
+            </p>
           )}
-        </div>
 
-        {/* Description */}
-        {description && (
-          <p className="text-sm text-neutral-600 line-clamp-2 mb-3">
-            {description}
-          </p>
-        )}
+          {/* Prompt count badge */}
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">
+              {promptCount} prompt{promptCount !== 1 ? 's' : ''}
+            </Badge>
+          </div>
+        </CardContent>
 
-        {/* Prompt count badge */}
-        <div className="flex items-center gap-2 mb-3">
-          <span className="inline-flex items-center rounded-full bg-neutral-100 px-2.5 py-0.5 text-xs font-medium text-neutral-600">
-            {promptCount} prompt{promptCount !== 1 ? 's' : ''}
-          </span>
-        </div>
-
-        {/* Spacer to push footer to bottom */}
-        <div className="flex-grow" />
-
-        {/* Footer */}
-        <div className="flex items-center justify-between pt-3 border-t border-neutral-100">
+        <CardFooter className="pt-3 border-t flex items-center justify-between">
           {/* Stats */}
-          <div className="flex items-center gap-3 text-xs text-neutral-500">
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
             <span title={`Updated ${updatedAt.toLocaleDateString()}`}>
-              Updated {formatDate(updatedAt)}
+              Updated {formatRelativeDate(updatedAt)}
             </span>
           </div>
 
           {/* Quick Actions (only for owners) */}
           {isOwner && (
             <div className="flex items-center gap-1">
-              <button
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
                 onClick={handleEdit}
-                className="p-1.5 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100"
                 title="Edit collection"
                 aria-label="Edit collection"
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                  />
-                </svg>
-              </button>
-              <button
+                <Pencil className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 hover:text-destructive hover:bg-destructive/10"
                 onClick={handleDelete}
-                className="p-1.5 rounded-md text-neutral-400 hover:text-error-600 hover:bg-error-50"
                 title="Delete collection"
                 aria-label="Delete collection"
               >
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-              </button>
+                <Trash2 className="h-4 w-4" />
+              </Button>
             </div>
           )}
-        </div>
-      </article>
+        </CardFooter>
+      </Card>
     </Link>
   );
 }
@@ -195,32 +145,29 @@ export function CollectionCard({
  */
 export function CollectionCardSkeleton() {
   return (
-    <div className="card p-4 animate-pulse">
-      {/* Header */}
-      <div className="flex items-start gap-2 mb-2">
-        <div className="w-8 h-8 bg-neutral-200 rounded-md" />
-        <div className="h-5 bg-neutral-200 rounded w-3/4" />
-      </div>
-
-      {/* Description */}
-      <div className="space-y-2 mb-3">
-        <div className="h-4 bg-neutral-100 rounded w-full" />
-        <div className="h-4 bg-neutral-100 rounded w-5/6" />
-      </div>
-
-      {/* Badge */}
-      <div className="mb-3">
-        <div className="h-5 bg-neutral-100 rounded-full w-20" />
-      </div>
-
-      {/* Footer */}
-      <div className="flex items-center justify-between pt-3 border-t border-neutral-100">
-        <div className="h-4 bg-neutral-100 rounded w-24" />
-        <div className="flex gap-1">
-          <div className="h-7 w-7 bg-neutral-100 rounded" />
-          <div className="h-7 w-7 bg-neutral-100 rounded" />
+    <Card className="h-full">
+      <CardHeader className="pb-2">
+        <div className="flex items-start gap-2">
+          <Skeleton className="w-8 h-8 rounded-md" />
+          <Skeleton className="h-5 w-3/4" />
         </div>
-      </div>
-    </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        <div className="space-y-2 mb-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+        </div>
+        <Skeleton className="h-5 w-20 rounded-full" />
+      </CardContent>
+
+      <CardFooter className="pt-3 border-t flex items-center justify-between">
+        <Skeleton className="h-4 w-24" />
+        <div className="flex gap-1">
+          <Skeleton className="h-7 w-7 rounded" />
+          <Skeleton className="h-7 w-7 rounded" />
+        </div>
+      </CardFooter>
+    </Card>
   );
 }

--- a/cursormvp/app/packages/web-app/src/components/workspaces/WorkspaceCard.tsx
+++ b/cursormvp/app/packages/web-app/src/components/workspaces/WorkspaceCard.tsx
@@ -4,9 +4,15 @@
  * WorkspaceCard Component
  *
  * Displays a workspace summary in a card format.
+ * Uses shadcn/ui Card component and Lucide icons.
  */
 
 import Link from 'next/link';
+import { Users, FileText } from 'lucide-react';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatShortDate } from '@/lib/date';
 
 interface WorkspaceCardProps {
   id: string;
@@ -30,103 +36,70 @@ export function WorkspaceCard({
   promptCount,
   joinedAt,
 }: WorkspaceCardProps) {
-  const roleColors = {
-    OWNER: 'bg-amber-50 text-amber-700',
-    ADMIN: 'bg-purple-50 text-purple-700',
-    MEMBER: 'bg-neutral-100 text-neutral-600',
-  };
-
-  const formatDate = (date: Date) => {
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  };
+  // Map roles to badge variants
+  const roleVariant = {
+    OWNER: 'owner',
+    ADMIN: 'admin',
+    MEMBER: 'member',
+  } as const;
 
   return (
-    <Link href={`/workspaces/${slug}`} className="block">
-      <article className="card p-5 hover:shadow-md transition-shadow duration-200 h-full flex flex-col">
-        {/* Header */}
-        <div className="flex items-start gap-3 mb-3">
-          {/* Workspace Icon/Image */}
-          {image ? (
-            <img
-              src={image}
-              alt={name}
-              className="w-12 h-12 rounded-lg object-cover"
-            />
-          ) : (
-            <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-white text-lg font-bold">
-              {name.charAt(0).toUpperCase()}
+    <Link href={`/workspaces/${slug}`} className="block h-full">
+      <Card className="h-full flex flex-col hover:shadow-md transition-shadow duration-200">
+        <CardHeader className="pb-3">
+          <div className="flex items-start gap-3">
+            {/* Workspace Icon/Image */}
+            {image ? (
+              <img
+                src={image}
+                alt={name}
+                className="w-12 h-12 rounded-lg object-cover"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-lg bg-gradient-to-br from-primary/80 to-primary flex items-center justify-center text-primary-foreground text-lg font-bold">
+                {name.charAt(0).toUpperCase()}
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <h3 className="text-base font-semibold text-foreground line-clamp-1">
+                {name}
+              </h3>
+              <p className="text-sm text-muted-foreground">/{slug}</p>
             </div>
+            <Badge variant={roleVariant[role]} className="flex-shrink-0">
+              {role.charAt(0) + role.slice(1).toLowerCase()}
+            </Badge>
+          </div>
+        </CardHeader>
+
+        <CardContent className="flex-grow pb-3">
+          {/* Description */}
+          {description && (
+            <p className="text-sm text-muted-foreground line-clamp-2">
+              {description}
+            </p>
           )}
-          <div className="flex-1 min-w-0">
-            <h3 className="text-base font-semibold text-neutral-900 line-clamp-1">
-              {name}
-            </h3>
-            <p className="text-sm text-neutral-500">/{slug}</p>
-          </div>
-          <span
-            className={`flex-shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${roleColors[role]}`}
-          >
-            {role.charAt(0) + role.slice(1).toLowerCase()}
-          </span>
-        </div>
+        </CardContent>
 
-        {/* Description */}
-        {description && (
-          <p className="text-sm text-neutral-600 line-clamp-2 mb-4">
-            {description}
+        <CardFooter className="pt-4 border-t flex flex-col items-start gap-2">
+          {/* Stats */}
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Users className="h-4 w-4" aria-hidden="true" />
+              <span>{memberCount} members</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <FileText className="h-4 w-4" aria-hidden="true" />
+              <span>{promptCount} prompts</span>
+            </div>
+          </div>
+
+          {/* Joined date */}
+          <p className="text-xs text-muted-foreground/70">
+            Joined {formatShortDate(joinedAt)}
           </p>
-        )}
-
-        {/* Spacer */}
-        <div className="flex-grow" />
-
-        {/* Stats */}
-        <div className="flex items-center gap-4 pt-4 border-t border-neutral-100">
-          <div className="flex items-center gap-1.5 text-sm text-neutral-500">
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
-              />
-            </svg>
-            <span>{memberCount} members</span>
-          </div>
-          <div className="flex items-center gap-1.5 text-sm text-neutral-500">
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-            <span>{promptCount} prompts</span>
-          </div>
-        </div>
-
-        {/* Joined date */}
-        <p className="text-xs text-neutral-400 mt-2">
-          Joined {formatDate(joinedAt)}
-        </p>
-      </article>
+        </CardFooter>
+      </Card>
     </Link>
   );
 }
@@ -136,23 +109,32 @@ export function WorkspaceCard({
  */
 export function WorkspaceCardSkeleton() {
   return (
-    <div className="card p-5 animate-pulse">
-      <div className="flex items-start gap-3 mb-3">
-        <div className="w-12 h-12 rounded-lg bg-neutral-200" />
-        <div className="flex-1">
-          <div className="h-5 bg-neutral-200 rounded w-3/4 mb-1" />
-          <div className="h-4 bg-neutral-100 rounded w-1/2" />
+    <Card className="h-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-start gap-3">
+          <Skeleton className="w-12 h-12 rounded-lg" />
+          <div className="flex-1">
+            <Skeleton className="h-5 w-3/4 mb-1" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+          <Skeleton className="h-5 w-16 rounded-full" />
         </div>
-        <div className="h-5 bg-neutral-100 rounded-full w-16" />
-      </div>
-      <div className="space-y-2 mb-4">
-        <div className="h-4 bg-neutral-100 rounded w-full" />
-        <div className="h-4 bg-neutral-100 rounded w-2/3" />
-      </div>
-      <div className="flex gap-4 pt-4 border-t border-neutral-100">
-        <div className="h-4 bg-neutral-100 rounded w-24" />
-        <div className="h-4 bg-neutral-100 rounded w-20" />
-      </div>
-    </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+      </CardContent>
+
+      <CardFooter className="pt-4 border-t flex flex-col items-start gap-2">
+        <div className="flex gap-4">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <Skeleton className="h-3 w-28" />
+      </CardFooter>
+    </Card>
   );
 }

--- a/cursormvp/app/packages/web-app/src/lib/date.ts
+++ b/cursormvp/app/packages/web-app/src/lib/date.ts
@@ -1,0 +1,64 @@
+/**
+ * Date formatting utilities
+ *
+ * Shared date formatting functions for consistent display across the app.
+ */
+
+/**
+ * Format a date as a relative time string (e.g., "Today", "Yesterday", "3 days ago")
+ * Falls back to short date format for older dates.
+ */
+export function formatRelativeDate(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return 'Today';
+  } else if (diffDays === 1) {
+    return 'Yesterday';
+  } else if (diffDays < 7) {
+    return `${diffDays} days ago`;
+  } else {
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+    });
+  }
+}
+
+/**
+ * Format a date in short format (e.g., "Jan 15, 2024")
+ */
+export function formatShortDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Format a date in full format (e.g., "January 15, 2024")
+ */
+export function formatFullDate(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Format a date with time (e.g., "Jan 15, 2024 at 3:30 PM")
+ */
+export function formatDateTime(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/cursormvp/bun.lock
+++ b/cursormvp/bun.lock
@@ -99,7 +99,7 @@
         "@trpc/react-query": "^11.0.0-rc.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
-        "lucide-react": "^0.446.0",
+        "lucide-react": "^0.555.0",
         "next": "^14.2.0",
         "next-auth": "^5.0.0-beta.22",
         "posthog-js": "^1.298.1",
@@ -1236,7 +1236,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.446.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg=="],
+    "lucide-react": ["lucide-react@0.555.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA=="],
 
     "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 


### PR DESCRIPTION
## Summary
- Add shared date formatter utility (`lib/date.ts`) to remove code duplication
- Migrate PromptCard, CollectionCard, and WorkspaceCard to use shadcn/ui components
- Replace inline SVG icons with Lucide icons for consistency
- Use semantic color tokens (foreground, muted-foreground, primary, destructive)

## Changes
- **PromptCard**: Uses Card, Badge, Button, Skeleton from shadcn/ui
- **CollectionCard**: Uses Card, Badge, Button, Skeleton from shadcn/ui
- **WorkspaceCard**: Uses Card, Badge, Skeleton, role-based badge variants

## Test plan
- [ ] Verify cards render correctly on /prompts page
- [ ] Verify cards render correctly on /collections page
- [ ] Verify cards render correctly on /workspaces page
- [ ] Test button hover states and click handlers
- [ ] Test skeleton loading states

Closes #5, #6, #7, #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)