### PR TITLE
fix(extension): Resolve TypeScript errors in browser-extension package

### DIFF
--- a/cursormvp/app/packages/browser-extension/src/background/service-worker.ts
+++ b/cursormvp/app/packages/browser-extension/src/background/service-worker.ts
@@ -50,11 +50,12 @@ browser.commands.onCommand.addListener(async (command) => {
 });
 
 // Handle messages from content scripts and popup
-browser.runtime.onMessage.addListener((message: ExtensionMessage, sender) => {
+browser.runtime.onMessage.addListener((message: unknown, sender: Runtime.MessageSender) => {
   // Return a promise for async handling
-  return handleMessage(message, sender).catch((error) => {
+  const typedMessage = message as ExtensionMessage;
+  return handleMessage(typedMessage, sender).catch((error) => {
     console.error('[Distill] Message handling error:', error);
-    return { success: false, error: error.message };
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
   });
 });
 

--- a/cursormvp/app/packages/browser-extension/src/content/main.ts
+++ b/cursormvp/app/packages/browser-extension/src/content/main.ts
@@ -382,13 +382,14 @@ async function openCaptureModal(): Promise<void> {
 }
 
 // Listen for messages from background script and popup
-browser.runtime.onMessage.addListener((message: ExtensionMessage, _sender, sendResponse) => {
-  console.log('[Distill] Content script received message:', message.type);
+browser.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  const typedMessage = message as ExtensionMessage;
+  console.log('[Distill] Content script received message:', typedMessage.type);
 
   // Handle async operations properly
   (async () => {
     try {
-      switch (message.type) {
+      switch (typedMessage.type) {
         case MessageTypes.CAPTURE_CONVERSATION: {
           console.log('[Distill] Starting conversation capture...');
           const capturedData = await buildCapturedConversation();
@@ -442,7 +443,7 @@ browser.runtime.onMessage.addListener((message: ExtensionMessage, _sender, sendR
         }
 
         default:
-          console.warn('[Distill] Unknown message type:', message.type);
+          console.warn('[Distill] Unknown message type:', typedMessage.type);
           sendResponse({ success: false, error: 'Unknown message type' });
       }
     } catch (error) {

--- a/cursormvp/app/packages/browser-extension/src/shared/analytics.ts
+++ b/cursormvp/app/packages/browser-extension/src/shared/analytics.ts
@@ -25,9 +25,18 @@ let analyticsEnabled = true;
 /**
  * Initialize extension analytics.
  */
+interface AnalyticsStorage {
+  analyticsSessionId?: string;
+  analyticsEnabled?: boolean;
+  userId?: string;
+}
+
 export async function initExtensionAnalytics(): Promise<void> {
   // Generate or retrieve session ID
-  const storage = await browser.storage.local.get(['analyticsSessionId', 'analyticsEnabled']);
+  const storage = (await browser.storage.local.get([
+    'analyticsSessionId',
+    'analyticsEnabled',
+  ])) as AnalyticsStorage;
 
   if (storage.analyticsEnabled === false) {
     analyticsEnabled = false;
@@ -38,7 +47,7 @@ export async function initExtensionAnalytics(): Promise<void> {
   await browser.storage.local.set({ analyticsSessionId: sessionId });
 
   // Check for user ID from auth
-  const authStorage = await browser.storage.local.get(['userId']);
+  const authStorage = (await browser.storage.local.get(['userId'])) as AnalyticsStorage;
   userId = authStorage.userId || null;
 }
 

--- a/cursormvp/app/packages/browser-extension/src/shared/browser-api.ts
+++ b/cursormvp/app/packages/browser-extension/src/shared/browser-api.ts
@@ -15,7 +15,7 @@
  * - Chrome's chrome.* namespace → shimmed to browser.*
  */
 
-import browserPolyfill from 'webextension-polyfill';
+import browserPolyfill, { type Tabs, type Cookies, type Menus } from 'webextension-polyfill';
 
 /**
  * Unified browser API that works on Chrome and Firefox.
@@ -59,12 +59,12 @@ export const runtime = {
  * Type-safe wrapper for tabs operations
  */
 export const tabs = {
-  query: (queryInfo: browser.Tabs.QueryQueryInfoType) => browser.tabs.query(queryInfo),
+  query: (queryInfo: Tabs.QueryQueryInfoType) => browser.tabs.query(queryInfo),
   sendMessage: <T = unknown>(tabId: number, message: unknown) =>
     browser.tabs.sendMessage(tabId, message) as Promise<T>,
-  create: (createProperties: browser.Tabs.CreateCreatePropertiesType) =>
+  create: (createProperties: Tabs.CreateCreatePropertiesType) =>
     browser.tabs.create(createProperties),
-  update: (tabId: number, updateProperties: browser.Tabs.UpdateUpdatePropertiesType) =>
+  update: (tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType) =>
     browser.tabs.update(tabId, updateProperties),
 };
 
@@ -72,10 +72,10 @@ export const tabs = {
  * Type-safe wrapper for cookies operations
  */
 export const cookies = {
-  getAll: (details: browser.Cookies.GetAllDetailsType) => browser.cookies.getAll(details),
-  get: (details: browser.Cookies.GetDetailsType) => browser.cookies.get(details),
-  set: (details: browser.Cookies.SetDetailsType) => browser.cookies.set(details),
-  remove: (details: browser.Cookies.RemoveDetailsType) => browser.cookies.remove(details),
+  getAll: (details: Cookies.GetAllDetailsType) => browser.cookies.getAll(details),
+  get: (details: Cookies.GetDetailsType) => browser.cookies.get(details),
+  set: (details: Cookies.SetDetailsType) => browser.cookies.set(details),
+  remove: (details: Cookies.RemoveDetailsType) => browser.cookies.remove(details),
 };
 
 /**
@@ -90,7 +90,7 @@ export const commands = {
  * Type-safe wrapper for context menus
  */
 export const contextMenus = {
-  create: (createProperties: browser.Menus.CreateCreatePropertiesType) =>
+  create: (createProperties: Menus.CreateCreatePropertiesType) =>
     browser.contextMenus.create(createProperties),
   remove: (menuItemId: string | number) => browser.contextMenus.remove(menuItemId),
   removeAll: () => browser.contextMenus.removeAll(),

--- a/cursormvp/app/packages/web-app/src/components/ui/progress.tsx
+++ b/cursormvp/app/packages/web-app/src/components/ui/progress.tsx
@@ -5,21 +5,24 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn('relative h-4 w-full overflow-hidden rounded-full bg-secondary', className)}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
+interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string;
+}
+
+const Progress = React.forwardRef<React.ElementRef<typeof ProgressPrimitive.Root>, ProgressProps>(
+  ({ className, value, indicatorClassName, ...props }, ref) => (
+    <ProgressPrimitive.Root
+      ref={ref}
+      className={cn('relative h-4 w-full overflow-hidden rounded-full bg-secondary', className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className={cn('h-full w-full flex-1 bg-primary transition-all', indicatorClassName)}
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  )
+);
 Progress.displayName = ProgressPrimitive.Root.displayName;
 
 export { Progress };


### PR DESCRIPTION
## Summary
Fixes CI type-check failure that occurred after merging PR #63. The browser-extension package had TypeScript errors related to webextension-polyfill types and storage API typing.

### Changes
- Fix webextension-polyfill namespace imports (`Tabs`, `Cookies`, `Menus` types)
- Add proper type assertions for message listeners in service-worker and content script
- Add `AnalyticsStorage` interface for storage API typing
- Add `CaptureResponse` and `StatsStorage` interfaces in popup App
- Add `indicatorClassName` prop to Progress component

## Test plan
- [x] `bun run type-check` passes locally
- [ ] CI type-check workflow passes
- [ ] Extension builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)